### PR TITLE
randomized health/attack for monster/player.json

### DIFF
--- a/client/src/data/Monster.json
+++ b/client/src/data/Monster.json
@@ -42,11 +42,11 @@
   {
     "id": "5",
     "name": "Brent Abruzese",
-    "class": "The Cursed One",
-    "health": "2500",
-    "smallAttack": "90000000",
-    "bigAttack": "90000000",
-    "specialAttack": "800",
+    "class": "The Legend",
+    "health": "100000000",
+    "smallAttack": "9999999",
+    "bigAttack": "9999999",
+    "specialAttack": "9999999",
     "img": "images/FiendLord.jpg"
   },
   {
@@ -54,7 +54,7 @@
     "name": "Kuma",
     "class": "Fiend Soldier",
     "health": "1000",
-    "smallAttack": "18",
+    "smallAttack": "17",
     "bigAttack": "19",
     "specialAttack": "80",
     "img": "images/FiendSoldier.jpg"
@@ -74,9 +74,172 @@
     "name": "Tinder",
     "class": "Fire Elemental",
     "health": "850",
-    "smallAttack": "18",
+    "smallAttack": "20",
     "bigAttack": "29",
     "specialAttack": "80",
     "img": "images/FireElemental.jpg"
+<<<<<<< Updated upstream
+=======
+  },
+  {
+    "id": "9",
+    "name": "Charger",
+    "class": "Armored Mastodon",
+    "health": "950",
+    "smallAttack": "21",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/ArmoredCharger.jpg"
+  },
+  {
+    "id": "10",
+    "name": "Bloodfury",
+    "class": "Manticore",
+    "health": "500",
+    "smallAttack": "50",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/Bloodfury.jpg"
+  },
+  {
+    "id": "11",
+    "name": "Dark Pegasus",
+    "class": "Winged Horse",
+    "health": "650",
+    "smallAttack": "17",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/DarkPegasus.jpg"
+  },
+  {
+    "id": "12",
+    "name": "Balduur",
+    "class": "Dark Viking",
+    "health": "900",
+    "smallAttack": "12",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/DarkViking.jpg"
+  },
+  {
+    "id": "13",
+    "name": "Frostbite",
+    "class": "Ice Dragon",
+    "health": "1050",
+    "smallAttack": "11",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/IceDragon.jpeg"
+  },
+  {
+    "id": "14",
+    "name": "Lorelei the Corrupted",
+    "class": "Necromancer",
+    "health": "650",
+    "smallAttack": "38",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/LoreleitheCorrupted.jpg"
+  },
+  {
+    "id": "15",
+    "name": "Bluntus",
+    "class": "Raging Rhino",
+    "health": "850",
+    "smallAttack": "20",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/RagingRhino.jpg"
+  },
+  {
+    "id": "16",
+    "name": "Cassandra",
+    "class": "Sea Dragoness",
+    "health": "750",
+    "smallAttack": "23",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/SeaDragoness.jpg"
+  },
+  {
+    "id": "17",
+    "name": "Skarpa",
+    "class": "Jagged Beast",
+    "health": "1000",
+    "smallAttack": "19",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/SkarpaBeast.jpg"
+  },
+  {
+    "id": "18",
+    "name": "Water Colossus",
+    "class": "Water Elemental",
+    "health": "1050",
+    "smallAttack": "10",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/WaterColossus.jpg"
+  },
+  {
+    "id": "19",
+    "name": "Wasteland Devourer",
+    "class": "Desert Beast",
+    "health": "800",
+    "smallAttack": "25",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/WastelandDevourer.jpg"
+  },
+  {
+    "id": "20",
+    "name": "Kyrolax",
+    "class": "Undead",
+    "health": "650",
+    "smallAttack": "30",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/UndeadDragon.jpg"
+  },
+  {
+    "id": "21",
+    "name": "Dromdrug",
+    "class": "Undead",
+    "health": "650",
+    "smallAttack": "28",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/UndeadRaider.jpg"
+  },
+  {
+    "id": "22",
+    "name": "Crackle",
+    "class": "Thunderlizard",
+    "health": "975",
+    "smallAttack": "16",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/Thunderlizard.jpg"
+  },
+  {
+    "id": "23",
+    "name": "Blitz",
+    "class": "Elvish Pyromancer",
+    "health": "450",
+    "smallAttack": "50",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/ElvishPyromancer.jpg"
+  },
+  {
+    "id": "24",
+    "name": "Crush",
+    "class": "Deep Seabeast",
+    "health": "2000",
+    "smallAttack": "9",
+    "bigAttack": "29",
+    "specialAttack": "80",
+    "img": "images/DeepSeabeast.jpg"
+>>>>>>> Stashed changes
   }
 ]

--- a/client/src/data/Player.json
+++ b/client/src/data/Player.json
@@ -77,5 +77,88 @@
     "bigAttack": "42",
     "specialAttack": "91",
     "img": "images/Mage.jpg"
+<<<<<<< Updated upstream
+=======
+  },
+  {
+    "id": "9",
+    "name": "Mars",
+    "class": "Ancient Hero",
+    "health": "150",
+    "smallAttack": "38",
+    "bigAttack": "60",
+    "specialAttack": "91",
+    "img": "images/Mars.jpeg"
+  },
+  {
+    "id": "10",
+    "name": "Arminius",
+    "class": "Heavy Calvary",
+    "health": "150",
+    "smallAttack": "28",
+    "bigAttack": "70",
+    "specialAttack": "91",
+    "img": "images/Arminius.jpg"
+  },
+  {
+    "id": "11",
+    "name": "Clecomell",
+    "class": "Dragonmaster",
+    "health": "150",
+    "smallAttack": "19",
+    "bigAttack": "50",
+    "specialAttack": "391",
+    "img": "images/Clecomell.jpg"
+  },
+  {
+    "id": "12",
+    "name": "Acantha",
+    "class": "Demon Hunter",
+    "health": "150",
+    "smallAttack": "30",
+    "bigAttack": "47",
+    "specialAttack": "91",
+    "img": "images/DemonHunter.jpg"
+  },
+  {
+    "id": "13",
+    "name": "Graldor",
+    "class": "Dwarf Viking",
+    "health": "150",
+    "smallAttack": "35",
+    "bigAttack": "52",
+    "specialAttack": "91",
+    "img": "images/Graldor.jpg"
+  },
+  {
+    "id": "14",
+    "name": "Kurdran",
+    "class": "Gryphon Rider",
+    "health": "150",
+    "smallAttack": "25",
+    "bigAttack": "40",
+    "specialAttack": "91",
+    "img": "images/GryphonRider.jpg"
+  },
+  {
+    "id": "15",
+    "name": "Jimmy the Guy",
+    "class": "Space Outlaw",
+    "health": "150",
+    "smallAttack": "33",
+    "bigAttack": "39",
+    "specialAttack": "91",
+    "img": "images/JimmytheGuy.jpg"
+  },
+  {
+    "id": "16",
+    "name": "Jehoel",
+    "class": "Angelic Knight",
+    "health": "150",
+    "smallAttack": "33",
+    "bigAttack": "56",
+    "specialAttack": "91",
+    "img": "images/TheCosmicKnight.jpg"
+>>>>>>> Stashed changes
   }
 ]


### PR DESCRIPTION
Had to stash this and push it in another branch. I just went into Player.json and Monster.json and put in attack/health values that were balanced i.e. if a monster has a really high attack value, their health is significantly lower than other monsters so its easier to kill, but you can also die faster because they hit harder. I also randomized the attack/health values for the playable characters, so there's some sort of diversity in choosing a character, and not just a different skin. 